### PR TITLE
fix: redirect to setup wizard on first start

### DIFF
--- a/backend/routers/setup.py
+++ b/backend/routers/setup.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from templating import templates
 import bcrypt
 from sqlalchemy import func, select
@@ -8,6 +8,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database import User, get_db, is_setup_complete, set_setting
 
 router = APIRouter(prefix="/setup")
+
+
+@router.get("/status")
+async def setup_status(db: AsyncSession = Depends(get_db)):
+    return JSONResponse({"setup_complete": await is_setup_complete(db)})
 
 
 @router.get("", response_class=HTMLResponse)

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useState, useEffect, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/Button';
 import { useAuthStore } from '@/stores/auth';
@@ -12,6 +12,15 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/setup/status')
+      .then((r) => r.json())
+      .then((d) => {
+        if (!d.setup_complete) window.location.href = '/setup';
+      })
+      .catch(() => {});
+  }, []);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Fixes #2 — setup wizard doesn't run on first start
- After the Jinja2 → Next.js refactor, the frontend bypassed the backend's setup-complete check, showing the login screen instead of the setup wizard
- Added `GET /setup/status` endpoint that returns `{"setup_complete": true/false}`
- Login page now checks setup status on mount and redirects to `/setup` if not complete

## Test plan
- [ ] Fresh install: verify `/setup` wizard appears automatically
- [ ] After setup complete: verify login page loads normally without redirect
- [ ] Direct `/setup` access after completion: verify redirect to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)