### PR TITLE
fix: complete CSRF middleware integration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -233,12 +233,15 @@ async def inject_globals(request: Request, call_next):
 
     is_api = request.url.path.startswith("/api/")
 
+    # Generate CSRF token for this request (sets cookie on first visit)
+    from csrf import generate_csrf_token, set_csrf_cookie, validate_csrf, csrf_error_response
+    generate_csrf_token(request)
+
     # CSRF protection for state-changing methods
     # Skip for: API-key-authenticated requests, /api/v1/ (has own API key auth layer)
     has_api_key = bool(request.headers.get("X-API-Key") or request.query_params.get("api_key"))
     is_api_v1 = request.url.path.startswith("/api/v1/")
     if request.method in ("POST", "PUT", "DELETE", "PATCH") and not has_api_key and not is_api_v1:
-        from csrf import validate_csrf, csrf_error_response
         content_type = request.headers.get("content-type", "")
         form_data = None
         if "form" in content_type:
@@ -288,6 +291,9 @@ async def inject_globals(request: Request, call_next):
     request.state.csp_nonce = _secrets.token_urlsafe(16)
 
     response = await call_next(request)
+
+    # Set CSRF cookie if newly generated
+    set_csrf_cookie(request, response)
 
     # Security headers
     response.headers["X-Frame-Options"] = "DENY"

--- a/backend/templating.py
+++ b/backend/templating.py
@@ -49,13 +49,13 @@ templates.env.filters["localtime"] = localtime
 
 def _csrf_input(request):
     """Return an HTML hidden input with the CSRF token."""
-    token = getattr(getattr(request, "state", None), "csrf_token", "")
+    token = getattr(getattr(request, "state", None), "_csrf_token", "")
     return f'<input type="hidden" name="csrf_token" value="{html_escape(token)}">'
 
 
 def _csrf_meta(request):
     """Return a meta tag with the CSRF token (for JS fetch calls)."""
-    token = getattr(getattr(request, "state", None), "csrf_token", "")
+    token = getattr(getattr(request, "state", None), "_csrf_token", "")
     return f'<meta name="csrf-token" content="{html_escape(token)}">'
 
 


### PR DESCRIPTION
## Summary
- Fixes #6 — Setup form fails with `403 CSRF validation failed`
- `generate_csrf_token()` and `set_csrf_cookie()` were defined in `csrf.py` but never called from the middleware, so the `ng_csrf` cookie was never set
- `templating.py` read `request.state.csrf_token` but `csrf.py` stored `request.state._csrf_token` (attribute name mismatch)
- This blocked **all** non-skip POST/PUT/DELETE/PATCH requests (setup, settings, host management, etc.)

## Changes
- **`backend/main.py`**: Call `generate_csrf_token(request)` before processing + `set_csrf_cookie(request, response)` after `call_next`
- **`backend/templating.py`**: Fix attribute name `csrf_token` → `_csrf_token` in both `_csrf_input()` and `_csrf_meta()`

## Test plan
- [x] All 119 existing tests pass
- [ ] Fresh docker-compose setup: verify setup form submits without 403
- [ ] Verify login works after setup completes
- [ ] Verify frontend CSRF-protected operations (add host, change settings) work