### PR TITLE
Server-side ed25519 signing for agent auto-updates

### DIFF
--- a/backend/routers/agents.py
+++ b/backend/routers/agents.py
@@ -18,6 +18,7 @@ from database import AsyncSessionLocal, PingHost, get_setting, set_setting
 from ratelimit import rate_limit
 from models.agent import Agent
 from models.agent_install_token import AgentInstallToken
+from services import agent_signing
 from services.websocket import broadcast_agent_metric
 
 
@@ -567,6 +568,8 @@ async def install_linux(request: Request):
     # without a token query-param we emit a placeholder that will visibly
     # fail at enrollment time instead of silently using something valid.
     enrollment_key = install_token or "NO_INSTALL_TOKEN_PROVIDED"
+    # Embed the update-signing public key so the agent verifies signed updates.
+    update_public_key = agent_signing.public_key_hex()
 
     script = f'''#!/bin/bash
 set -e
@@ -633,7 +636,8 @@ cat > "$CONFIG_FILE" << CONF
 {{
   "server": "$SERVER",
   "token": "$TOKEN",
-  "interval": 30
+  "interval": 30,
+  "update_public_key": "{update_public_key}"
 }}
 CONF
 
@@ -703,6 +707,8 @@ async def install_windows(request: Request):
         scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
         server_url = f"{scheme}://{request.url.netloc}"
     enrollment_key = install_token or "NO_INSTALL_TOKEN_PROVIDED"
+    # Embed the update-signing public key so the agent verifies signed updates.
+    update_public_key = agent_signing.public_key_hex()
 
     script = f'''# ── Nodeglow Agent Installer for Windows ─────────────────────────────────────
 $ErrorActionPreference = "Stop"
@@ -773,7 +779,8 @@ Write-Host "  [5/8] Writing configuration..."
 {{
   "server": "$Server",
   "token": "$Token",
-  "interval": 30
+  "interval": 30,
+  "update_public_key": "{update_public_key}"
 }}
 "@ | Set-Content -Path "$InstallDir\\config.json" -Encoding ASCII -Force
 
@@ -917,10 +924,11 @@ async def agent_download(request: Request, platform: str):
 # ── API: Agent version check (for auto-update) ────────────────────────────────
 
 _agent_file_cache: dict[str, tuple[str, float]] = {}  # platform -> (hash, mtime)
+_agent_sig_cache: dict[str, tuple[str, float]] = {}    # platform -> (signature, mtime)
 
 
-def _get_agent_hash(platform: str) -> str:
-    """Get SHA256 hash of the current agent binary/script. Cached by mtime."""
+def _agent_binary_path(platform: str) -> Path | None:
+    """Resolve the file served by agent_download for a platform, or None."""
     if platform == "windows":
         path = Path("static/nodeglow-agent.exe")
     else:
@@ -928,8 +936,13 @@ def _get_agent_hash(platform: str) -> str:
         path = Path("static/nodeglow-agent-linux")
         if not path.exists():
             path = Path("static/nodeglow-agent-linux.py")
+    return path if path.exists() else None
 
-    if not path.exists():
+
+def _get_agent_hash(platform: str) -> str:
+    """Get SHA256 hash of the current agent binary/script. Cached by mtime."""
+    path = _agent_binary_path(platform)
+    if path is None:
         return ""
 
     mtime = path.stat().st_mtime
@@ -942,12 +955,45 @@ def _get_agent_hash(platform: str) -> str:
     return h
 
 
+def _get_agent_signature(platform: str) -> str:
+    """Detached ed25519 signature (hex) over the served binary. Cached by mtime.
+
+    Signs the exact bytes agent_download returns so the agent can verify the
+    download against its embedded public key. Empty string if no binary exists.
+    """
+    path = _agent_binary_path(platform)
+    if path is None:
+        return ""
+
+    mtime = path.stat().st_mtime
+    cached = _agent_sig_cache.get(platform)
+    if cached and cached[1] == mtime:
+        return cached[0]
+
+    sig = agent_signing.sign_bytes(path.read_bytes())
+    _agent_sig_cache[platform] = (sig, mtime)
+    return sig
+
+
 @router.get("/api/agent/version/{platform}")
 async def agent_version(platform: str):
-    """Returns the current agent version hash. Agents poll this to check for updates."""
+    """Returns the current agent version hash + ed25519 signature.
+
+    Agents poll this to check for updates; the signature lets agents that have
+    a configured update_public_key verify the binary before applying it.
+    """
     if platform not in ("windows", "linux"):
         return JSONResponse({"error": "Invalid platform"}, status_code=400)
-    return {"hash": _get_agent_hash(platform)}
+    return {
+        "hash": _get_agent_hash(platform),
+        "signature": _get_agent_signature(platform),
+    }
+
+
+@router.get("/api/agent/update-public-key")
+async def agent_update_public_key():
+    """Public half of the agent-update signing key (hex), for agents to embed."""
+    return {"public_key": agent_signing.public_key_hex()}
 
 
 # ── API: List agents (JSON) ─────────────────────────────────────────────────

--- a/backend/services/agent_signing.py
+++ b/backend/services/agent_signing.py
@@ -1,0 +1,68 @@
+"""Ed25519 signing for agent auto-updates.
+
+The server holds an ed25519 private key (persisted in ``DATA_DIR``). Agents embed
+the matching public key — delivered inside the server-generated install script,
+i.e. over the operator's authenticated browser session — and verify a detached
+signature over the downloaded binary before applying an update.
+
+This is defense-in-depth on top of enforced TLS: even a compromised transport or
+a malicious update host cannot make an agent run an unsigned binary, because the
+attacker does not hold the private key.
+
+Wire format (must match the Rust agent in agent/src/updater.rs):
+  * public key: hex-encoded 32 raw ed25519 bytes
+  * signature:  hex-encoded 64 raw ed25519 bytes, computed over the exact binary
+                bytes served by ``GET /agents/download/{platform}``
+  * algorithm:  pure ed25519 (not ed25519ph) over the raw message
+"""
+import logging
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from config import DATA_DIR
+
+log = logging.getLogger(__name__)
+
+_KEY_FILE = DATA_DIR / "agent_update_ed25519.key"
+
+_private_key: Ed25519PrivateKey | None = None
+
+
+def get_private_key() -> Ed25519PrivateKey:
+    """Return the persistent signing key, generating it on first use.
+
+    The raw 32-byte private key is stored 0600 in DATA_DIR and cached in-process.
+    """
+    global _private_key
+    if _private_key is not None:
+        return _private_key
+
+    if _KEY_FILE.exists():
+        _private_key = Ed25519PrivateKey.from_private_bytes(_KEY_FILE.read_bytes())
+    else:
+        _private_key = Ed25519PrivateKey.generate()
+        _KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _KEY_FILE.write_bytes(_private_key.private_bytes_raw())
+        try:
+            _KEY_FILE.chmod(0o600)
+        except OSError:
+            pass
+        log.info("Generated new agent-update signing key at %s", _KEY_FILE)
+
+    return _private_key
+
+
+def public_key_hex() -> str:
+    """Hex-encoded raw ed25519 public key (64 hex chars) for agents to embed."""
+    return get_private_key().public_key().public_bytes_raw().hex()
+
+
+def sign_bytes(data: bytes) -> str:
+    """Hex-encoded detached ed25519 signature (128 hex chars) over ``data``."""
+    return get_private_key().sign(data).hex()
+
+
+def _reset_for_tests() -> None:
+    """Drop the cached key so tests can exercise generation/persistence."""
+    global _private_key
+    _private_key = None

--- a/backend/tests/test_routers/test_agent_update_signing.py
+++ b/backend/tests/test_routers/test_agent_update_signing.py
@@ -1,0 +1,54 @@
+"""Router tests for the signed agent-update endpoints."""
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from services import agent_signing
+
+
+@pytest.fixture(autouse=True)
+def _fresh_key():
+    agent_signing._reset_for_tests()
+    if agent_signing._KEY_FILE.exists():
+        agent_signing._KEY_FILE.unlink()
+    yield
+    agent_signing._reset_for_tests()
+    if agent_signing._KEY_FILE.exists():
+        agent_signing._KEY_FILE.unlink()
+
+
+async def test_update_public_key_endpoint(client):
+    resp = await client.get("/api/agent/update-public-key")
+    assert resp.status_code == 200
+    pub = resp.json()["public_key"]
+    assert len(bytes.fromhex(pub)) == 32
+
+
+async def test_version_endpoint_shape(client):
+    resp = await client.get("/api/agent/version/linux")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "hash" in body and "signature" in body
+
+
+async def test_version_signature_verifies_against_binary(client, tmp_path, monkeypatch):
+    """The signature served for a binary must verify with the public key."""
+    import routers.agents as agents
+
+    binary = tmp_path / "nodeglow-agent-linux"
+    binary.write_bytes(b"\x7fELF" + b"a real-ish agent binary" * 50)
+    monkeypatch.setattr(agents, "_agent_binary_path", lambda platform: binary)
+    agents._agent_sig_cache.clear()
+    agents._agent_file_cache.clear()
+
+    ver = (await client.get("/api/agent/version/linux")).json()
+    pub_hex = (await client.get("/api/agent/update-public-key")).json()["public_key"]
+
+    assert ver["hash"] and ver["signature"]
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(pub_hex))
+    # Verifies over the exact served bytes — the check the Rust agent performs.
+    pub.verify(bytes.fromhex(ver["signature"]), binary.read_bytes())
+
+
+async def test_invalid_platform_rejected(client):
+    resp = await client.get("/api/agent/version/bogus")
+    assert resp.status_code == 400

--- a/backend/tests/test_services/test_agent_signing.py
+++ b/backend/tests/test_services/test_agent_signing.py
@@ -1,0 +1,54 @@
+"""Tests for ed25519 agent-update signing.
+
+The round-trip test mirrors exactly what the Rust agent does
+(agent/src/updater.rs: hex-decode the 32-byte public key + 64-byte signature,
+verify pure ed25519 over the raw downloaded bytes), so a green test here means a
+server-produced signature will verify on the agent.
+"""
+import pytest
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from services import agent_signing
+
+
+@pytest.fixture(autouse=True)
+def _fresh_key():
+    """Each test starts without a cached key and removes any generated file."""
+    agent_signing._reset_for_tests()
+    if agent_signing._KEY_FILE.exists():
+        agent_signing._KEY_FILE.unlink()
+    yield
+    agent_signing._reset_for_tests()
+    if agent_signing._KEY_FILE.exists():
+        agent_signing._KEY_FILE.unlink()
+
+
+def test_key_is_generated_and_persisted():
+    pub1 = agent_signing.public_key_hex()
+    assert agent_signing._KEY_FILE.exists()
+    # A fresh process (cleared cache) must reload the SAME key from disk.
+    agent_signing._reset_for_tests()
+    assert agent_signing.public_key_hex() == pub1
+
+
+def test_public_key_and_signature_sizes():
+    assert len(bytes.fromhex(agent_signing.public_key_hex())) == 32
+    sig = agent_signing.sign_bytes(b"the agent binary bytes")
+    assert len(bytes.fromhex(sig)) == 64
+
+
+def test_signature_verifies_with_public_key():
+    data = b"\x7fELF" + b"fake binary payload" * 100
+    sig_hex = agent_signing.sign_bytes(data)
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(agent_signing.public_key_hex()))
+    # Must not raise — this is the exact check the Rust client performs.
+    pub.verify(bytes.fromhex(sig_hex), data)
+
+
+def test_tampered_payload_fails_verification():
+    data = b"\x7fELF original payload"
+    sig_hex = agent_signing.sign_bytes(data)
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(agent_signing.public_key_hex()))
+    with pytest.raises(InvalidSignature):
+        pub.verify(bytes.fromhex(sig_hex), data + b"tampered")


### PR DESCRIPTION
Adds the server half of agent-update signing (the client side landed in Phase 2). Persistent ed25519 key in DATA_DIR; `/api/agent/version/{platform}` returns a detached signature over the served binary; `/api/agent/update-public-key` exposes the public key; Linux+Windows install scripts embed it in the agent config so fresh installs verify. Backward compatible. Round-trip verified; full suite 359 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)