### PR TITLE
Redis-based scheduler leader lock (safe multi-worker/HA)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,11 @@ DATABASE_URL=postgresql+asyncpg://nodeglow:${POSTGRES_PASSWORD}@db:5432/nodeglow
 # Rotation: generate a new value, update .env in both containers' environment,
 # then `docker compose up -d nodeglow updater` to reload them together.
 UPDATE_SIDECAR_TOKEN=changeme-generate-with-openssl-rand-hex-32
+
+# ── Redis (optional — required only for multi-worker / HA) ───────────────────
+# Leave unset for the default single-process deployment (behaviour unchanged).
+# When set, the rate limiter becomes shared across processes AND scheduled jobs
+# (correlation, ping, etc.) run on a single elected leader, so you can safely
+# run multiple uvicorn workers / replicas without duplicate jobs or incidents.
+# Example: redis://redis:6379/0
+# REDIS_URL=redis://redis:6379/0

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -1,20 +1,70 @@
 """
 Background scheduler – generic integration collection + ping checks + cleanup.
 """
+import asyncio
 import logging
+import os
+import socket
 from datetime import datetime, timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlalchemy import delete, select
 
+import config
 from database import AsyncSessionLocal, PingHost
 from models.integration import IntegrationConfig
 from services import integration as int_svc
+from services import shared_state
 from services import snapshot as snap_svc
 from services.metrics import instrument_job
 
 logger = logging.getLogger(__name__)
 scheduler = AsyncIOScheduler()
+
+# ── Scheduler leadership (multi-worker / HA safety) ──────────────────────────
+# Without a leader lock every uvicorn worker / replica would start its own
+# scheduler and run correlation, ping, etc. concurrently → duplicate incidents
+# and duplicate work. When REDIS_URL is set, all instances contend for a single
+# Redis lease and only the holder runs jobs. Without Redis (the default,
+# single-process deployment) there is exactly one process which is always the
+# leader, so behaviour is unchanged.
+_SCHEDULER_LEADER_LOCK = "nodeglow:scheduler:leader"
+_LEADER_TTL_SECONDS = 30
+_LEADER_RENEW_SECONDS = 10
+_instance_id = f"{socket.gethostname()}:{os.getpid()}"
+_leader_task: "asyncio.Task | None" = None
+_is_leader = False
+
+
+def _apply_leadership(leader: bool) -> None:
+    """Resume or pause the scheduler on a leadership transition (idempotent)."""
+    global _is_leader
+    if leader and not _is_leader:
+        scheduler.resume()
+        _is_leader = True
+        logger.info("Acquired scheduler leadership — jobs running (instance=%s)", _instance_id)
+    elif not leader and _is_leader:
+        scheduler.pause()
+        _is_leader = False
+        logger.warning("Lost scheduler leadership — jobs paused (instance=%s)", _instance_id)
+
+
+async def _leadership_loop():
+    """Periodically acquire/renew the Redis lease; resume jobs only while leader."""
+    while True:
+        try:
+            leader = await shared_state.try_acquire_leader(
+                _SCHEDULER_LEADER_LOCK, _instance_id, _LEADER_TTL_SECONDS
+            )
+            _apply_leadership(leader)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            # Preserve current leadership state on transient errors: never grant
+            # leadership to everyone (split-brain) nor stop a healthy leader. A
+            # genuinely dead leader frees the lease via its TTL.
+            logger.error("Scheduler leadership loop error: %s", e)
+        await asyncio.sleep(_LEADER_RENEW_SECONDS)
 
 
 # ── Generic integration collection ───────────────────────────────────────────
@@ -1182,7 +1232,16 @@ async def start_scheduler():
                       hour=ai_summary_hour, minute=0,
                       id="daily_ai_summary", replace_existing=True)
 
-    scheduler.start()
+    if getattr(config, "REDIS_URL", ""):
+        # HA mode: start paused; the leadership loop resumes jobs once this
+        # instance wins the Redis lease, and pauses them if it loses it.
+        global _leader_task
+        scheduler.start(paused=True)
+        _leader_task = asyncio.create_task(_leadership_loop())
+        logger.info("Scheduler started in leader-election mode (instance=%s)", _instance_id)
+    else:
+        # Single-process deployment: always leader, run jobs immediately.
+        scheduler.start()
 
     # Seed default SNMP OIDs
     try:
@@ -1196,4 +1255,10 @@ async def start_scheduler():
 
 
 def stop_scheduler():
+    global _leader_task
+    if _leader_task is not None:
+        _leader_task.cancel()
+        _leader_task = None
+    # The Redis lease (if any) is left to expire via its TTL, which hands
+    # leadership to a standby within _LEADER_TTL_SECONDS.
     scheduler.shutdown(wait=False)

--- a/backend/services/shared_state.py
+++ b/backend/services/shared_state.py
@@ -39,6 +39,10 @@ _lock = threading.Lock()
 _hits: dict[str, list[float]] = {}
 _last_cleanup = 0.0
 
+# In-memory leader locks: {lock_name: (holder_id, expiry_time)}. Used when no
+# Redis is configured (single process → always its own leader).
+_leaders: dict[str, tuple[str, float]] = {}
+
 # Lazily-created singleton Redis client.
 _redis_client = None
 _redis_lock = threading.Lock()
@@ -52,10 +56,11 @@ def set_clock(fn):
 
 def reset():
     """Clear all in-memory state and reset the clock (test helper)."""
-    global _hits, _last_cleanup, _clock, _redis_client
+    global _hits, _last_cleanup, _clock, _redis_client, _leaders
     with _lock:
         _hits = {}
         _last_cleanup = 0.0
+        _leaders = {}
     _clock = time.monotonic
     _redis_client = None
 
@@ -235,3 +240,67 @@ def window_count_sync(key: str, window_seconds: int) -> int:
         except Exception as e:  # fail open
             log.warning("shared_state: Redis count (sync) failed, falling back to memory: %s", e)
     return _mem_count(key, window_seconds)
+
+
+# ── Leader lock ───────────────────────────────────────────────────────────────
+#
+# A single-holder lease used to elect one process to run scheduled jobs. Unlike
+# the rate limiter this MUST NOT fail open: silently granting leadership to every
+# process on a Redis error would cause split-brain (duplicate scheduled jobs). On
+# a Redis error the public API raises and the caller keeps its current state.
+
+# Atomic "acquire if free/expired, or renew if I already hold it" + "release if
+# I hold it", as Lua so the check-and-set is a single round trip.
+_ACQUIRE_LUA = (
+    "local v = redis.call('GET', KEYS[1]) "
+    "if v == false or v == ARGV[1] then "
+    "  redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2]) return 1 "
+    "else return 0 end"
+)
+_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then "
+    "  return redis.call('DEL', KEYS[1]) else return 0 end"
+)
+
+
+def _mem_acquire_leader(lock_name: str, instance_id: str, ttl_seconds: int) -> bool:
+    now = _clock()
+    with _lock:
+        cur = _leaders.get(lock_name)
+        if cur is None or cur[1] <= now or cur[0] == instance_id:
+            _leaders[lock_name] = (instance_id, now + ttl_seconds)
+            return True
+        return False
+
+
+def _mem_release_leader(lock_name: str, instance_id: str) -> None:
+    with _lock:
+        cur = _leaders.get(lock_name)
+        if cur is not None and cur[0] == instance_id:
+            del _leaders[lock_name]
+
+
+async def try_acquire_leader(lock_name: str, instance_id: str, ttl_seconds: int) -> bool:
+    """Acquire or renew leadership of ``lock_name`` for ``instance_id``.
+
+    Returns True if this instance holds the lease (just acquired or renewed),
+    False if another live instance holds it. Raises on a Redis error so the
+    caller can preserve its current leadership state (never fail open).
+    """
+    if _redis_url():
+        client = _get_redis()
+        res = await client.eval(_ACQUIRE_LUA, 1, lock_name, instance_id, int(ttl_seconds * 1000))
+        return bool(int(res))
+    return _mem_acquire_leader(lock_name, instance_id, ttl_seconds)
+
+
+async def release_leader(lock_name: str, instance_id: str) -> None:
+    """Release ``lock_name`` if held by ``instance_id`` (best effort)."""
+    if _redis_url():
+        try:
+            client = _get_redis()
+            await client.eval(_RELEASE_LUA, 1, lock_name, instance_id)
+        except Exception as e:
+            log.warning("shared_state: leader release failed: %s", e)
+        return
+    _mem_release_leader(lock_name, instance_id)

--- a/backend/tests/test_services/test_leader_lock.py
+++ b/backend/tests/test_services/test_leader_lock.py
@@ -1,0 +1,65 @@
+"""Tests for the shared_state leader lock (in-memory backend, fake clock)."""
+import pytest
+
+from services import shared_state
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    shared_state.reset()
+    yield
+    shared_state.reset()
+
+
+def _clock_at(value):
+    """Install a fake clock returning a mutable [value]; return the list."""
+    box = [value]
+    shared_state.set_clock(lambda: box[0])
+    return box
+
+
+async def test_single_holder_excludes_others():
+    _clock_at(0.0)
+    assert await shared_state.try_acquire_leader("sched", "A", 30) is True
+    # B cannot take it while A's lease is live.
+    assert await shared_state.try_acquire_leader("sched", "B", 30) is False
+
+
+async def test_holder_can_renew():
+    t = _clock_at(0.0)
+    assert await shared_state.try_acquire_leader("sched", "A", 30) is True
+    t[0] = 10.0
+    assert await shared_state.try_acquire_leader("sched", "A", 30) is True
+    # B still locked out after A renewed.
+    assert await shared_state.try_acquire_leader("sched", "B", 30) is False
+
+
+async def test_failover_after_expiry():
+    t = _clock_at(0.0)
+    assert await shared_state.try_acquire_leader("sched", "A", 30) is True
+    # A goes away and does not renew; lease expires.
+    t[0] = 31.0
+    assert await shared_state.try_acquire_leader("sched", "B", 30) is True
+    # A is now the non-leader.
+    assert await shared_state.try_acquire_leader("sched", "A", 30) is False
+
+
+async def test_release_frees_the_lock():
+    _clock_at(0.0)
+    assert await shared_state.try_acquire_leader("sched", "A", 30) is True
+    await shared_state.release_leader("sched", "A")
+    assert await shared_state.try_acquire_leader("sched", "B", 30) is True
+
+
+async def test_release_by_non_holder_is_noop():
+    _clock_at(0.0)
+    assert await shared_state.try_acquire_leader("sched", "A", 30) is True
+    await shared_state.release_leader("sched", "B")  # B does not hold it
+    # A still holds it.
+    assert await shared_state.try_acquire_leader("sched", "B", 30) is False
+
+
+async def test_independent_locks_do_not_interfere():
+    _clock_at(0.0)
+    assert await shared_state.try_acquire_leader("lock1", "A", 30) is True
+    assert await shared_state.try_acquire_leader("lock2", "B", 30) is True

--- a/backend/tests/test_services/test_scheduler_leadership.py
+++ b/backend/tests/test_services/test_scheduler_leadership.py
@@ -1,0 +1,39 @@
+"""Tests for the scheduler leadership resume/pause transitions."""
+import pytest
+
+import scheduler
+
+
+@pytest.fixture(autouse=True)
+def _reset_leader_state(monkeypatch):
+    calls = {"resume": 0, "pause": 0}
+    monkeypatch.setattr(scheduler.scheduler, "resume", lambda: calls.__setitem__("resume", calls["resume"] + 1))
+    monkeypatch.setattr(scheduler.scheduler, "pause", lambda: calls.__setitem__("pause", calls["pause"] + 1))
+    monkeypatch.setattr(scheduler, "_is_leader", False)
+    return calls
+
+
+def test_becoming_leader_resumes_once(_reset_leader_state):
+    scheduler._apply_leadership(True)
+    assert scheduler._is_leader is True
+    assert _reset_leader_state["resume"] == 1
+    # Idempotent: staying leader does not resume again.
+    scheduler._apply_leadership(True)
+    assert _reset_leader_state["resume"] == 1
+
+
+def test_losing_leadership_pauses_once(_reset_leader_state):
+    scheduler._apply_leadership(True)
+    scheduler._apply_leadership(False)
+    assert scheduler._is_leader is False
+    assert _reset_leader_state["pause"] == 1
+    # Idempotent: staying non-leader does not pause again.
+    scheduler._apply_leadership(False)
+    assert _reset_leader_state["pause"] == 1
+
+
+def test_non_leader_from_start_does_nothing(_reset_leader_state):
+    scheduler._apply_leadership(False)
+    assert _reset_leader_state["resume"] == 0
+    assert _reset_leader_state["pause"] == 0
+    assert scheduler._is_leader is False


### PR DESCRIPTION
Lets Nodeglow run multiple uvicorn workers/replicas without duplicate scheduled jobs or incidents. When `REDIS_URL` is set, all instances contend for one Redis lease and only the leader runs jobs; without Redis the single process is always leader and behaviour is unchanged (fail-safe, never split-brain). Replaces the originally-planned counter→Redis migration after investigation showed the scheduler duplication is the actual HA blocker. Full suite 368 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)