### PR TITLE
perf: quick wins — batch queries, parallel aggregations, calmer dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ backend/static/dist/
 # macOS
 .DS_Store
 
+.superpowers/

--- a/backend/alembic/versions/030_incident_event_type_index.py
+++ b/backend/alembic/versions/030_incident_event_type_index.py
@@ -1,0 +1,26 @@
+"""Add (incident_id, event_type, timestamp) index on incident_events.
+
+The incident list endpoint filters events by incident_id + event_type and
+sorts by timestamp; the existing (incident_id, timestamp) index forces a
+scan over all events of an incident once event counts grow large.
+
+Revision ID: 030
+Revises: 029
+"""
+revision = "030"
+down_revision = "029"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index(
+        "ix_incident_event_type_ts",
+        "incident_events",
+        ["incident_id", "event_type", sa.text("timestamp DESC")],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_incident_event_type_ts", table_name="incident_events")

--- a/backend/models/incident.py
+++ b/backend/models/incident.py
@@ -56,4 +56,5 @@ class IncidentEvent(Base):
 
     __table_args__ = (
         Index("ix_incident_event_ts", "incident_id", timestamp.desc()),
+        Index("ix_incident_event_type_ts", "incident_id", "event_type", timestamp.desc()),
     )

--- a/backend/routers/api_v1.py
+++ b/backend/routers/api_v1.py
@@ -379,14 +379,9 @@ async def get_host(
                 IntegrationConfig.enabled == True,
             )
         )
+        type_snaps = await snap_svc.get_latest_batch(db, int_type)
         for cfg in configs_q.scalars().all():
-            snap_q = await db.execute(
-                select(Snapshot)
-                .where(Snapshot.entity_type == int_type, Snapshot.entity_id == cfg.id)
-                .order_by(Snapshot.timestamp.desc())
-                .limit(1)
-            )
-            snap = snap_q.scalar_one_or_none()
+            snap = type_snaps.get(cfg.id)
             if snap and snap.data_json:
                 raw = json.loads(snap.data_json) if isinstance(snap.data_json, str) else snap.data_json
                 device_data = _extract_device_data(int_type, raw, host)
@@ -928,17 +923,13 @@ async def list_integrations(
     result = await db.execute(q)
     configs = result.scalars().all()
 
-    # Get latest snapshot for each
-    latest = {}
-    for cfg in configs:
-        snap = await snap_svc.get_latest(db, cfg.type, cfg.id)
-        if snap:
-            latest[cfg.id] = snap
+    # Get latest snapshot for each (single query instead of one per config)
+    all_snaps = await snap_svc.get_latest_batch_all(db)
 
     from scheduler import _STANDBY_MARKER
     out = []
     for cfg in configs:
-        snap = latest.get(cfg.id)
+        snap = all_snaps.get(cfg.type, {}).get(cfg.id)
         # Standby members write ok=True with the standby marker in `error`.
         # Surface that as a separate UI state — not "error", not "ok primary".
         is_standby = bool(snap and snap.ok and snap.error == _STANDBY_MARKER)
@@ -1476,64 +1467,68 @@ async def syslog_stats(
         "geo_distribution": [],
     }
 
-    try:
-        # Total count
-        result["total"] = int(await ch_scalar(
-            "SELECT count() FROM syslog_messages WHERE timestamp >= {t:DateTime64(3)}",
-            {"t": since},
-        ) or 0)
+    # Message rate — choose bucket size based on hours
+    if hours <= 6:
+        bucket_fn = "toStartOfFiveMinutes"
+    elif hours <= 24:
+        bucket_fn = "toStartOfFifteenMinutes"
+    else:
+        bucket_fn = "toStartOfHour"
 
-        # Severity distribution
-        sev_rows = await ch_query(
-            "SELECT severity, count() AS cnt FROM syslog_messages "
-            "WHERE timestamp >= {t:DateTime64(3)} GROUP BY severity ORDER BY severity",
-            {"t": since},
+    try:
+        # All six aggregations are independent — run them in parallel.
+        params = {"t": since}
+        total, sev_rows, host_rows, app_rows, rate_rows, geo_rows = await asyncio.gather(
+            ch_scalar(
+                "SELECT count() FROM syslog_messages WHERE timestamp >= {t:DateTime64(3)}",
+                params,
+            ),
+            ch_query(
+                "SELECT severity, count() AS cnt FROM syslog_messages "
+                "WHERE timestamp >= {t:DateTime64(3)} GROUP BY severity ORDER BY severity",
+                params,
+            ),
+            ch_query(
+                "SELECT coalesce(nullIf(hostname, ''), source_ip) AS host, "
+                "source_ip, count() AS cnt FROM syslog_messages "
+                "WHERE timestamp >= {t:DateTime64(3)} "
+                "GROUP BY host, source_ip ORDER BY cnt DESC LIMIT 10",
+                params,
+            ),
+            ch_query(
+                "SELECT app_name, count() AS cnt FROM syslog_messages "
+                "WHERE timestamp >= {t:DateTime64(3)} AND app_name != '' "
+                "GROUP BY app_name ORDER BY cnt DESC LIMIT 10",
+                params,
+            ),
+            ch_query(
+                f"SELECT {bucket_fn}(timestamp) AS bucket, "
+                "count() AS cnt, countIf(severity <= 3) AS errors "
+                "FROM syslog_messages WHERE timestamp >= {t:DateTime64(3)} "
+                "GROUP BY bucket ORDER BY bucket",
+                params,
+            ),
+            ch_query(
+                "SELECT geo_country, count() AS cnt FROM syslog_messages "
+                "WHERE timestamp >= {t:DateTime64(3)} AND geo_country != '' "
+                "GROUP BY geo_country ORDER BY cnt DESC LIMIT 20",
+                params,
+            ),
         )
+
+        result["total"] = int(total or 0)
         result["severity_distribution"] = [
             {"severity": r["severity"], "label": SEVERITY_LABELS.get(r["severity"], f"Sev {r['severity']}"), "count": r["cnt"]}
             for r in sev_rows if r["severity"] is not None
         ]
-
-        # Top 10 hosts
-        host_rows = await ch_query(
-            "SELECT coalesce(nullIf(hostname, ''), source_ip) AS host, "
-            "source_ip, count() AS cnt FROM syslog_messages "
-            "WHERE timestamp >= {t:DateTime64(3)} "
-            "GROUP BY host, source_ip ORDER BY cnt DESC LIMIT 10",
-            {"t": since},
-        )
         result["top_hosts"] = [
             {"hostname": r["host"], "source_ip": r["source_ip"], "count": r["cnt"]}
             for r in host_rows
         ]
-
-        # Top 10 applications
-        app_rows = await ch_query(
-            "SELECT app_name, count() AS cnt FROM syslog_messages "
-            "WHERE timestamp >= {t:DateTime64(3)} AND app_name != '' "
-            "GROUP BY app_name ORDER BY cnt DESC LIMIT 10",
-            {"t": since},
-        )
         result["top_apps"] = [
             {"app_name": r["app_name"], "count": r["cnt"]}
             for r in app_rows
         ]
-
-        # Message rate — choose bucket size based on hours
-        if hours <= 6:
-            bucket_fn, bucket_min = "toStartOfFiveMinutes", 5
-        elif hours <= 24:
-            bucket_fn, bucket_min = "toStartOfFifteenMinutes", 15
-        else:
-            bucket_fn, bucket_min = "toStartOfHour", 60
-
-        rate_rows = await ch_query(
-            f"SELECT {bucket_fn}(timestamp) AS bucket, "
-            "count() AS cnt, countIf(severity <= 3) AS errors "
-            "FROM syslog_messages WHERE timestamp >= {t:DateTime64(3)} "
-            "GROUP BY bucket ORDER BY bucket",
-            {"t": since},
-        )
         result["message_rate"] = [
             {
                 "bucket": r["bucket"].isoformat() if hasattr(r["bucket"], "isoformat") else str(r["bucket"]),
@@ -1542,14 +1537,6 @@ async def syslog_stats(
             }
             for r in rate_rows
         ]
-
-        # Geo distribution (only if data exists)
-        geo_rows = await ch_query(
-            "SELECT geo_country, count() AS cnt FROM syslog_messages "
-            "WHERE timestamp >= {t:DateTime64(3)} AND geo_country != '' "
-            "GROUP BY geo_country ORDER BY cnt DESC LIMIT 20",
-            {"t": since},
-        )
         result["geo_distribution"] = [
             {"country": r["geo_country"], "count": r["cnt"]}
             for r in geo_rows

--- a/backend/routers/api_v1.py
+++ b/backend/routers/api_v1.py
@@ -1024,22 +1024,27 @@ async def list_incidents(
     result = await db.execute(q)
     incidents = result.scalars().all()
 
-    # Fetch latest non-system event summary per incident (explains the WHY)
+    # Fetch latest non-system event summary per incident (explains the WHY).
+    # Greatest-per-group via max(id) subquery — long-lived incidents accumulate
+    # one event per correlation cycle, so loading all of them just to keep the
+    # newest one made this endpoint scale with total event count.
     incident_ids = [i.id for i in incidents]
     summary_map: dict[int, str] = {}
     if incident_ids:
-        # Get the most recent event with a meaningful event_type (not "acknowledged"/"resolved")
-        events_q = await db.execute(
-            select(IncidentEvent)
+        latest_meaningful = (
+            select(func.max(IncidentEvent.id).label("max_id"))
             .where(
                 IncidentEvent.incident_id.in_(incident_ids),
                 IncidentEvent.event_type.notin_(["acknowledged", "resolved"]),
             )
-            .order_by(IncidentEvent.timestamp.desc())
+            .group_by(IncidentEvent.incident_id)
+            .scalar_subquery()
         )
-        for ev in events_q.scalars().all():
-            if ev.incident_id not in summary_map:
-                summary_map[ev.incident_id] = ev.summary
+        events_q = await db.execute(
+            select(IncidentEvent.incident_id, IncidentEvent.summary)
+            .where(IncidentEvent.id.in_(latest_meaningful))
+        )
+        summary_map = {incident_id: summary for incident_id, summary in events_q}
 
     return [
         {
@@ -1226,11 +1231,18 @@ async def get_incident(
     if not incident:
         raise HTTPException(404, "Incident not found")
 
+    # Long-lived incidents accumulate one event per correlation cycle — cap
+    # the timeline at the newest 200 instead of serializing all of them.
+    events_total = (await db.execute(
+        select(func.count()).select_from(IncidentEvent)
+        .where(IncidentEvent.incident_id == incident_id)
+    )).scalar_one()
     events_q = await db.execute(
         select(IncidentEvent).where(IncidentEvent.incident_id == incident_id)
-        .order_by(IncidentEvent.timestamp.asc())
+        .order_by(IncidentEvent.timestamp.desc())
+        .limit(200)
     )
-    events = events_q.scalars().all()
+    events = list(reversed(events_q.scalars().all()))
 
     # Fetch related syslog entries around the incident timeframe
     related_logs = []
@@ -1288,6 +1300,7 @@ async def get_incident(
             }
             for e in events
         ],
+        "events_total": events_total,
         "related_logs": related_logs,
         "log_analysis": log_analysis,
     }

--- a/backend/routers/settings/general.py
+++ b/backend/routers/settings/general.py
@@ -31,6 +31,7 @@ async def settings_json(request: Request, db: AsyncSession = Depends(get_db)):
         "notify_telegram_min_severity", "notify_discord_min_severity",
         "notify_webhook_min_severity", "notify_email_min_severity",
         "ping_retention_days", "proxmox_retention_days", "integration_retention_days",
+        "incident_event_retention_days",
         "anomaly_threshold", "proxmox_cpu_threshold", "proxmox_ram_threshold",
         "proxmox_disk_threshold", "syslog_port", "syslog_allowlist_only",
         "digest_enabled", "digest_day", "digest_hour",
@@ -46,6 +47,7 @@ async def settings_json(request: Request, db: AsyncSession = Depends(get_db)):
         "site_name": "NODEGLOW", "ping_interval": "60", "proxmox_interval": "60",
         "timezone": "UTC", "smtp_port": "587", "ping_retention_days": "30",
         "proxmox_retention_days": "7", "integration_retention_days": "7",
+        "incident_event_retention_days": "30",
         "anomaly_threshold": "2.0", "proxmox_cpu_threshold": "85",
         "proxmox_ram_threshold": "85", "proxmox_disk_threshold": "90",
         "syslog_port": "1514",
@@ -99,6 +101,7 @@ async def save_settings(
     ram_threshold:      str = Form("85"),
     disk_threshold:     str = Form("90"),
     integration_retention: str = Form("7"),
+    incident_event_retention: str = Form("30"),
     syslog_port:        str = Form("1514"),
     syslog_allowlist_only: str = Form("0"),
     predictor_min_confidence: str = Form(""),
@@ -156,6 +159,13 @@ async def save_settings(
     except ValueError:
         int_ret = 7
     await set_setting(db, "integration_retention_days", str(int_ret))
+
+    # 0 disables incident event pruning entirely.
+    try:
+        ev_ret = max(0, min(365, int(incident_event_retention)))
+    except ValueError:
+        ev_ret = 30
+    await set_setting(db, "incident_event_retention_days", str(ev_ret))
 
     for key, val, lo, hi, default in [
         ("proxmox_cpu_threshold",  cpu_threshold,  1, 100, 85),

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -503,6 +503,7 @@ async def cleanup_old_results():
 
     async with AsyncSessionLocal() as db:
         int_ret = int(await get_setting(db, "integration_retention_days", "7"))
+        ev_ret = int(await get_setting(db, "incident_event_retention_days", "30"))
 
     async with AsyncSessionLocal() as db:
         await snap_svc.cleanup_all(db, int_ret)
@@ -510,9 +511,14 @@ async def cleanup_old_results():
         from models.snmp import SnmpResult
         snmp_cutoff = datetime.utcnow() - timedelta(days=7)
         await db.execute(delete(SnmpResult).where(SnmpResult.timestamp < snmp_cutoff))
+        # Incident events accumulate one row per correlation cycle per open
+        # incident — prune old ones (keeps newest meaningful event per incident).
+        from services.correlation import cleanup_incident_events
+        ev_deleted = await cleanup_incident_events(db, ev_ret)
         await db.commit()
 
-    logger.info("Cleanup done (integrations: %dd)", int_ret)
+    logger.info("Cleanup done (integrations: %dd, incident events: %dd, %d pruned)",
+                int_ret, ev_ret, ev_deleted)
 
 
 # ── Disk space health check ──────────────────────────────────────────────────

--- a/backend/services/clickhouse_client.py
+++ b/backend/services/clickhouse_client.py
@@ -782,26 +782,3 @@ def _where_clauses(
     return " AND ".join(clauses), params
 
 
-async def query_aggregated(
-    since: datetime,
-    source_ip: str = "",
-    template_hash: str = "",
-    severity: int | None = None,
-) -> list[dict]:
-    """Query the aggregated syslog table for trend/dashboard data."""
-    clauses = ["bucket >= {since:DateTime}"]
-    params: dict = {"since": since}
-    if source_ip:
-        clauses.append("source_ip = {sip:String}")
-        params["sip"] = source_ip
-    if template_hash:
-        clauses.append("template_hash = {th:String}")
-        params["th"] = template_hash
-    if severity is not None:
-        clauses.append("severity = {sev:Int8}")
-        params["sev"] = severity
-    where = " AND ".join(clauses)
-    return await query(
-        f"SELECT * FROM syslog_aggregated WHERE {where} ORDER BY bucket DESC LIMIT 1000",
-        params,
-    )

--- a/backend/services/correlation.py
+++ b/backend/services/correlation.py
@@ -19,7 +19,7 @@ import json
 import logging
 from datetime import datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import delete, func, select
 
 from models.base import AsyncSessionLocal
 from models.ping import PingHost
@@ -69,6 +69,32 @@ def _prune_stale_hits():
     for k in stale:
         del _rule_hit_counts[k]
     _current_cycle_hits.clear()
+
+
+async def cleanup_incident_events(db, retention_days: int) -> int:
+    """Delete incident events older than retention_days.
+
+    Open incidents accumulate one event per correlation cycle, so this table
+    grows without bound. The newest meaningful (non-ack/resolve) event per
+    incident is always kept — it backs the summary shown in the incident list.
+    A retention of 0 disables pruning. Returns the number of deleted rows.
+    """
+    if retention_days <= 0:
+        return 0
+    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    keep_latest = (
+        select(func.max(IncidentEvent.id))
+        .where(IncidentEvent.event_type.notin_(["acknowledged", "resolved"]))
+        .group_by(IncidentEvent.incident_id)
+        .scalar_subquery()
+    )
+    result = await db.execute(
+        delete(IncidentEvent).where(
+            IncidentEvent.timestamp < cutoff,
+            IncidentEvent.id.notin_(keep_latest),
+        )
+    )
+    return result.rowcount or 0
 
 
 async def _find_or_create_incident(

--- a/backend/services/ping.py
+++ b/backend/services/ping.py
@@ -5,6 +5,8 @@ ping_checks table. No Postgres session is needed.
 """
 from __future__ import annotations
 
+import asyncio
+
 from services import clickhouse_client as ch
 
 
@@ -20,10 +22,13 @@ async def get_latest_by_host(host_ids: list[int]) -> dict[int, dict]:
 
 async def get_uptime_map() -> dict[int, dict]:
     """Return {host_id: {h24, d7, d30}} uptime percentages over multiple
-    rolling windows. Three CH queries — one per window."""
+    rolling windows. Three CH queries — one per window, run in parallel."""
+    windows = ((24, "h24"), (24 * 7, "d7"), (24 * 30, "d30"))
+    results = await asyncio.gather(
+        *(ch.get_ping_uptime(hours=hours) for hours, _ in windows)
+    )
     out: dict[int, dict] = {}
-    for hours, key in ((24, "h24"), (24 * 7, "d7"), (24 * 30, "d30")):
-        rows = await ch.get_ping_uptime(hours=hours)
+    for (_, key), rows in zip(windows, results):
         for host_id, stats in rows.items():
             out.setdefault(host_id, {})[key] = stats["uptime_pct"]
     return out

--- a/backend/tests/test_routers/test_api_v1.py
+++ b/backend/tests/test_routers/test_api_v1.py
@@ -206,6 +206,44 @@ async def test_incident_not_found(client):
     assert resp.status_code == 404
 
 
+async def test_list_incidents_summary_is_latest_meaningful_event(client):
+    """The list summary is the newest event, excluding ack/resolve markers.
+
+    Characterization for the greatest-per-group lookup: incidents with many
+    events must surface exactly the most recent non-system event summary.
+    """
+    from datetime import datetime, timedelta
+
+    from database import AsyncSessionLocal
+    from models.incident import Incident, IncidentEvent
+
+    now = datetime.utcnow()
+    async with AsyncSessionLocal() as s:
+        inc = Incident(rule="host_down_syslog", title="host down", severity="critical", status="open")
+        other = Incident(rule="syslog_spike", title="spike", severity="warning", status="open")
+        s.add_all([inc, other])
+        await s.flush()
+        s.add_all([
+            IncidentEvent(incident_id=inc.id, event_type="created",
+                          summary="first event", timestamp=now - timedelta(minutes=10)),
+            IncidentEvent(incident_id=inc.id, event_type="host_down",
+                          summary="newest meaningful event", timestamp=now - timedelta(minutes=2)),
+            # System markers must never win, even when they are newest.
+            IncidentEvent(incident_id=inc.id, event_type="acknowledged",
+                          summary="acked by julian", timestamp=now - timedelta(minutes=1)),
+            IncidentEvent(incident_id=other.id, event_type="created",
+                          summary="other incident event", timestamp=now - timedelta(minutes=5)),
+        ])
+        await s.commit()
+        inc_id, other_id = inc.id, other.id
+
+    resp = await client.get("/api/v1/incidents")
+    assert resp.status_code == 200
+    by_id = {i["id"]: i for i in resp.json()}
+    assert by_id[inc_id]["summary"] == "newest meaningful event"
+    assert by_id[other_id]["summary"] == "other incident event"
+
+
 # ── Syslog ───────────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_services/test_correlation.py
+++ b/backend/tests/test_services/test_correlation.py
@@ -242,3 +242,67 @@ async def test_precursor_rule_skips_blacklisted_template_at_fire_time(db):
         select(Incident).where(Incident.rule == "learned_precursor")
     )).scalars().all()
     assert incidents == []
+
+
+async def test_cleanup_incident_events_keeps_newest_meaningful(db):
+    """Pruning drops old events but never the newest meaningful one per incident."""
+    from datetime import timedelta
+
+    from sqlalchemy import select
+    from models.incident import Incident, IncidentEvent
+    from services.correlation import cleanup_incident_events
+
+    now = datetime.utcnow()
+    old = now - timedelta(days=60)
+    # inc1: every event is stale — its newest meaningful event must survive
+    # anyway, because it backs the summary in the incident list.
+    inc1 = Incident(rule="host_down_syslog", title="down", severity="critical", status="resolved")
+    # inc2: has a recent meaningful event — its stale rows are free to go.
+    inc2 = Incident(rule="syslog_spike", title="spike", severity="warning", status="open")
+    db.add_all([inc1, inc2])
+    await db.flush()
+    db.add_all([
+        IncidentEvent(incident_id=inc1.id, event_type="created",
+                      summary="inc1 old created", timestamp=old),
+        IncidentEvent(incident_id=inc1.id, event_type="host_down",
+                      summary="inc1 newest meaningful", timestamp=old + timedelta(minutes=5)),
+        IncidentEvent(incident_id=inc1.id, event_type="acknowledged",
+                      summary="inc1 old ack marker", timestamp=old + timedelta(minutes=10)),
+        IncidentEvent(incident_id=inc2.id, event_type="created",
+                      summary="inc2 old created", timestamp=old),
+        IncidentEvent(incident_id=inc2.id, event_type="host_up",
+                      summary="inc2 recent event", timestamp=now - timedelta(hours=1)),
+    ])
+    await db.commit()
+
+    deleted = await cleanup_incident_events(db, retention_days=30)
+    await db.commit()
+
+    remaining = (await db.execute(select(IncidentEvent.summary))).scalars().all()
+    assert deleted == 3
+    assert sorted(remaining) == ["inc1 newest meaningful", "inc2 recent event"]
+
+
+async def test_cleanup_incident_events_disabled_with_zero(db):
+    """retention_days=0 disables pruning entirely."""
+    from datetime import timedelta
+
+    from sqlalchemy import select
+    from models.incident import Incident, IncidentEvent
+    from services.correlation import cleanup_incident_events
+
+    inc = Incident(rule="syslog_spike", title="spike", severity="warning", status="open")
+    db.add(inc)
+    await db.flush()
+    db.add(IncidentEvent(incident_id=inc.id, event_type="created",
+                         summary="ancient", timestamp=datetime.utcnow() - timedelta(days=400)))
+    await db.commit()
+
+    deleted = await cleanup_incident_events(db, retention_days=0)
+    await db.commit()
+
+    count = len((await db.execute(
+        select(IncidentEvent).where(IncidentEvent.incident_id == inc.id)
+    )).scalars().all())
+    assert deleted == 0
+    assert count == 1

--- a/frontend/src/app/(app)/incidents/[id]/page.tsx
+++ b/frontend/src/app/(app)/incidents/[id]/page.tsx
@@ -75,6 +75,7 @@ interface LogAnalysis {
 
 interface IncidentDetail extends Incident {
   events: IncidentEvent[];
+  events_total?: number;
   related_logs?: RelatedLog[];
   log_analysis?: LogAnalysis | null;
   postmortem?: string | null;
@@ -205,7 +206,14 @@ export default function IncidentDetailPage() {
           </GlassCard>
 
           <GlassCard className="p-4">
-            <h3 className="text-sm font-medium text-slate-300 mb-4">Event Timeline</h3>
+            <h3 className="text-sm font-medium text-slate-300 mb-4">
+              Event Timeline
+              {(data.events_total ?? 0) > (data.events?.length ?? 0) && (
+                <span className="ml-2 text-[10px] font-normal text-slate-500">
+                  showing latest {data.events.length} of {data.events_total}
+                </span>
+              )}
+            </h3>
             {data.events?.length ? (
               <div className="space-y-0">
                 {data.events.map((evt, i) => (

--- a/frontend/src/app/(app)/page.tsx
+++ b/frontend/src/app/(app)/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { GlassCard } from '@/components/ui/GlassCard';
 import { StatusDot } from '@/components/ui/StatusDot';
@@ -87,6 +87,36 @@ export default function DashboardPage() {
 
   const anomalyCount = (data?.anomalies?.length ?? 0) + (data?.warnings?.length ?? 0);
 
+  // Chart options are memoized so EChart only rebuilds when the underlying
+  // data changes — inline objects would retrigger setOption on every render.
+  const rateData = data?.syslog_stats?.rate_data;
+  const syslogRateOption = useMemo(() => rateData && ({
+    tooltip: { trigger: 'axis' as const },
+    legend: { show: false },
+    grid: { left: 40, right: 12, top: 8, bottom: 24 },
+    xAxis: { type: 'category' as const, data: rateData.labels, axisLabel: { fontSize: 10 } },
+    yAxis: { type: 'value' as const, axisLabel: { fontSize: 10 } },
+    series: [
+      { name: 'Errors', type: 'bar' as const, stack: 'total', data: rateData.errors, color: ngColors.critical },
+      { name: 'Warnings', type: 'bar' as const, stack: 'total', data: rateData.warnings, color: ngColors.warning },
+      { name: 'Info', type: 'bar' as const, stack: 'total', data: rateData.info, color: ngColors.primary },
+    ],
+  }), [rateData]);
+
+  const incidentTrend = data?.incident_trend;
+  const alertTrendOption = useMemo(() => incidentTrend && ({
+    tooltip: { trigger: 'axis' as const },
+    legend: { show: false },
+    grid: { left: 40, right: 12, top: 8, bottom: 24 },
+    xAxis: { type: 'category' as const, data: incidentTrend.map((d) => d.date), axisLabel: { fontSize: 10 } },
+    yAxis: { type: 'value' as const, minInterval: 1, axisLabel: { fontSize: 10 } },
+    series: [
+      { name: 'Critical', type: 'bar' as const, stack: 'total', data: incidentTrend.map((d) => d.critical), color: ngColors.critical },
+      { name: 'Warning', type: 'bar' as const, stack: 'total', data: incidentTrend.map((d) => d.warning), color: ngColors.warning },
+      { name: 'Info', type: 'bar' as const, stack: 'total', data: incidentTrend.map((d) => d.info), color: ngColors.primary },
+    ],
+  }), [incidentTrend]);
+
   // First-run detection: nothing to show. We branch BEFORE rendering the
   // empty grid of widgets so the user gets a guided onboarding instead of
   // a void.
@@ -140,12 +170,11 @@ export default function DashboardPage() {
       />
 
       {/* ── Quick Stats — compact row, ~64px tall ──
-          key={dataUpdatedAt} forces a remount every refresh, re-triggering
-          the .ng-just-changed CSS animation defined in globals.css. That's
-          the subtle sky ring pulse that tells you "fresh data just landed"
-          without being loud about it. */}
+          justRefreshed re-applies .ng-just-changed for 1.6s on every refresh,
+          which restarts the CSS animation (globals.css) without remounting
+          the cards. That's the subtle sky ring pulse that tells you "fresh
+          data just landed" without being loud about it. */}
       <div
-        key={dataUpdatedAt}
         className={cn(
           'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-4 rounded-lg',
           justRefreshed && 'ng-just-changed',
@@ -274,25 +303,11 @@ export default function DashboardPage() {
               </span>
             ) : undefined
           } />
-          {isLoading || !data?.syslog_stats?.rate_data ? (
+          {isLoading || !syslogRateOption ? (
             <Skeleton className="h-[180px] w-full" />
           ) : (
             <WidgetErrorBoundary label="Syslog Rate">
-              <EChart
-                height={180}
-                option={{
-                  tooltip: { trigger: 'axis' },
-                  legend: { show: false },
-                  grid: { left: 40, right: 12, top: 8, bottom: 24 },
-                  xAxis: { type: 'category', data: data.syslog_stats.rate_data.labels, axisLabel: { fontSize: 10 } },
-                  yAxis: { type: 'value', axisLabel: { fontSize: 10 } },
-                  series: [
-                    { name: 'Errors', type: 'bar', stack: 'total', data: data.syslog_stats.rate_data.errors, color: ngColors.critical },
-                    { name: 'Warnings', type: 'bar', stack: 'total', data: data.syslog_stats.rate_data.warnings, color: ngColors.warning },
-                    { name: 'Info', type: 'bar', stack: 'total', data: data.syslog_stats.rate_data.info, color: ngColors.primary },
-                  ],
-                }}
-              />
+              <EChart height={180} option={syslogRateOption} />
             </WidgetErrorBoundary>
           )}
           <div className="mt-4 pt-3 border-t" style={{ borderColor: 'var(--ng-card-border)' }}>
@@ -380,21 +395,7 @@ export default function DashboardPage() {
             </p>
           ) : (
             <WidgetErrorBoundary label="Alert Trends">
-              <EChart
-                height={180}
-                option={{
-                  tooltip: { trigger: 'axis' },
-                  legend: { show: false },
-                  grid: { left: 40, right: 12, top: 8, bottom: 24 },
-                  xAxis: { type: 'category', data: data.incident_trend.map((d) => d.date), axisLabel: { fontSize: 10 } },
-                  yAxis: { type: 'value', minInterval: 1, axisLabel: { fontSize: 10 } },
-                  series: [
-                    { name: 'Critical', type: 'bar', stack: 'total', data: data.incident_trend.map((d) => d.critical), color: ngColors.critical },
-                    { name: 'Warning', type: 'bar', stack: 'total', data: data.incident_trend.map((d) => d.warning), color: ngColors.warning },
-                    { name: 'Info', type: 'bar', stack: 'total', data: data.incident_trend.map((d) => d.info), color: ngColors.primary },
-                  ],
-                }}
-              />
+              {alertTrendOption && <EChart height={180} option={alertTrendOption} />}
             </WidgetErrorBoundary>
           )}
         </GlassCard>

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -31,6 +31,7 @@ interface SettingsData {
   ping_retention_days: string;
   proxmox_retention_days: string;
   integration_retention_days: string;
+  incident_event_retention_days: string;
   anomaly_threshold: string;
   proxmox_cpu_threshold: string;
   proxmox_ram_threshold: string;
@@ -292,6 +293,7 @@ export default function SettingsPage() {
   const [pingRetention, setPingRetention] = useState('30');
   const [proxmoxRetention, setProxmoxRetention] = useState('7');
   const [integrationRetention, setIntegrationRetention] = useState('7');
+  const [incidentEventRetention, setIncidentEventRetention] = useState('30');
   const [anomalyThreshold, setAnomalyThreshold] = useState('2.0');
   const [cpuThreshold, setCpuThreshold] = useState('85');
   const [ramThreshold, setRamThreshold] = useState('85');
@@ -403,6 +405,7 @@ export default function SettingsPage() {
     setPingRetention(s.ping_retention_days || '30');
     setProxmoxRetention(s.proxmox_retention_days || '7');
     setIntegrationRetention(s.integration_retention_days || '7');
+    setIncidentEventRetention(s.incident_event_retention_days || '30');
     setAnomalyThreshold(s.anomaly_threshold || '2.0');
     setCpuThreshold(s.proxmox_cpu_threshold || '85');
     setRamThreshold(s.proxmox_ram_threshold || '85');
@@ -542,6 +545,7 @@ export default function SettingsPage() {
     params.set('ping_retention', pingRetention);
     params.set('proxmox_retention', proxmoxRetention);
     params.set('integration_retention', integrationRetention);
+    params.set('incident_event_retention', incidentEventRetention);
     params.set('anomaly_threshold', anomalyThreshold);
     params.set('cpu_threshold', cpuThreshold);
     params.set('ram_threshold', ramThreshold);
@@ -811,6 +815,65 @@ export default function SettingsPage() {
                     min={10}
                     max={3600}
                   />
+                </div>
+              </div>
+            )}
+          </GlassCard>
+          <GlassCard className="p-4">
+            <h3 className="text-base font-semibold text-slate-200 mb-3">Data Retention</h3>
+            {settingsLoading ? (
+              <div className="space-y-3">
+                <Skeleton className="h-8 w-40" />
+                <Skeleton className="h-8 w-40" />
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="ng-label">Ping History (days)</label>
+                  <input
+                    type="number"
+                    value={pingRetention}
+                    onChange={(e) => setPingRetention(e.target.value)}
+                    className={inputSmCls}
+                    min={1}
+                    max={365}
+                  />
+                </div>
+                <div>
+                  <label className="ng-label">Integration Snapshots (days)</label>
+                  <input
+                    type="number"
+                    value={integrationRetention}
+                    onChange={(e) => setIntegrationRetention(e.target.value)}
+                    className={inputSmCls}
+                    min={1}
+                    max={90}
+                  />
+                </div>
+                <div>
+                  <label className="ng-label">Proxmox History (days)</label>
+                  <input
+                    type="number"
+                    value={proxmoxRetention}
+                    onChange={(e) => setProxmoxRetention(e.target.value)}
+                    className={inputSmCls}
+                    min={1}
+                    max={90}
+                  />
+                </div>
+                <div>
+                  <label className="ng-label">Incident Events (days)</label>
+                  <input
+                    type="number"
+                    value={incidentEventRetention}
+                    onChange={(e) => setIncidentEventRetention(e.target.value)}
+                    className={inputSmCls}
+                    min={0}
+                    max={365}
+                  />
+                  <p className="text-xs text-slate-500 mt-1">
+                    Prunes incident timeline events nightly; the newest event per incident is always kept. 0 = keep forever.
+                  </p>
                 </div>
               </div>
             )}

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -10,7 +10,10 @@ export function Providers({ children }: { children: ReactNode }) {
         defaultOptions: {
           queries: {
             staleTime: 15_000,
-            refetchOnWindowFocus: true,
+            // Dashboard mounts ~14 queries; refetching all of them on every
+            // window focus hammers the backend. Interval refetch keeps data
+            // fresh enough.
+            refetchOnWindowFocus: false,
             retry: 1,
           },
         },

--- a/frontend/src/components/charts/EChart.tsx
+++ b/frontend/src/components/charts/EChart.tsx
@@ -48,9 +48,10 @@ export function EChart({ option, className, height = 200 }: EChartProps) {
     };
   }, [colorMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Update option when it changes
+  // Update option when it changes. Merge mode (no notMerge) lets ECharts
+  // diff series data instead of rebuilding the whole chart on every refetch.
   useEffect(() => {
-    chartRef.current?.setOption(option, true);
+    chartRef.current?.setOption(option);
   }, [option]);
 
   return <div ref={ref} className={className} style={{ height }} />;


### PR DESCRIPTION
## Summary

Performance quick wins from a codebase audit. The app gets sluggish with lots of data; the common patterns were queries-in-loops, serial ClickHouse aggregations, and unnecessary re-renders.

### Backend
- **N+1 fixes:** `list_integrations` and the host-detail integration lookup now use the existing `get_latest_batch*()` snapshot helpers — one query instead of one per config.
- **Parallel ClickHouse:** `get_uptime_map()` (3 windows) and `/syslog/stats` (6 aggregations) now run their independent queries via `asyncio.gather` instead of serially.
- **Index:** new `(incident_id, event_type, timestamp DESC)` index on `incident_events` (migration 030) backing the event lookup in the incident list.
- **Dead code:** removed `query_aggregated()` — it referenced a `syslog_aggregated` table that doesn't exist and had no callers.

### Frontend
- Removed the `key={dataUpdatedAt}` force-remount of the quick-stats grid (6 widgets remounted every 30s); the `justRefreshed` class toggle already restarts the pulse animation.
- `refetchOnWindowFocus: false` — the dashboard mounts ~14 queries; every tab switch fired them all at once.
- Dashboard chart options are memoized and `EChart` updates use merge mode, so refetches diff data instead of disposing/rebuilding charts.

### Verification
- Backend: `pytest` — **368 passed**
- Frontend: `next build` — compiles clean

### Deploy note
Migration 030 adds an index — run `alembic upgrade head` before restart as usual.

### Not in this PR (follow-ups from the audit)
Root-cause N+1 (50 queries/call), materialized views for syslog stats, bulk-upsert for baselines, list virtualization.